### PR TITLE
Fixing issues

### DIFF
--- a/FluentAutomation/BaseCommandProvider.cs
+++ b/FluentAutomation/BaseCommandProvider.cs
@@ -35,7 +35,7 @@ namespace FluentAutomation
                     {
                         var screenshotName = string.Format(CultureInfo.CurrentCulture, "ExpectFailed_{0}", DateTimeOffset.Now.Date.ToFileTime());
                         ex.ScreenshotPath = System.IO.Path.Combine(Settings.ScreenshotPath, screenshotName);
-                        this.TakeScreenshot(screenshotName);
+                        this.TakeScreenshot(ex.ScreenshotPath);
                     }
 
                     throw;
@@ -46,7 +46,7 @@ namespace FluentAutomation
                     {
                         var screenshotName = string.Format(CultureInfo.CurrentCulture, "ActionFailed_{0}", DateTimeOffset.Now.Date.ToFileTime());
                         ex.ScreenshotPath = System.IO.Path.Combine(Settings.ScreenshotPath, screenshotName);
-                        this.TakeScreenshot(screenshotName);
+                        this.TakeScreenshot(ex.ScreenshotPath);
                     }
 
                     throw;
@@ -124,7 +124,7 @@ namespace FluentAutomation
                 // If func is still not valid, assume we've hit the timeout.
                 if (isFuncValid == false)
                 {
-                    throw new FluentException("Conditional wait passed the timeout [{0}ms] for expression [{1}].", lastException, timeout.TotalMilliseconds, conditionFunc.ToExpressionString());
+                    throw new FluentException("Conditional wait passed the timeout [{0}ms] for expression [{1}]. See InnerException for details of the last FluentException thrown.", lastException, timeout.TotalMilliseconds, conditionFunc.ToExpressionString());
                 }
             }, false);
         }
@@ -171,7 +171,7 @@ namespace FluentAutomation
                 // If an exception was thrown the last loop, assume we hit the timeout
                 if (threwException == true)
                 {
-                    throw new FluentException("Conditional wait passed the timeout [{0}ms]. See InnerException for details of the last FluentException thrown.", lastFluentException, timeout.TotalMilliseconds);
+                    throw new FluentException("Conditional wait passed the timeout [{0}ms] for expression [{1}]. See InnerException for details of the last FluentException thrown.", lastFluentException, timeout.TotalMilliseconds, conditionAction.ToExpressionString());
                 }
             }, false);
         }

--- a/FluentAutomation/ExpectProvider.cs
+++ b/FluentAutomation/ExpectProvider.cs
@@ -301,7 +301,7 @@ namespace FluentAutomation
 
         private bool IsTextMatch(string elementText, string text)
         {
-            return elementText.Equals(text, StringComparison.InvariantCultureIgnoreCase);
+            return String.Equals(elementText, text, StringComparison.InvariantCultureIgnoreCase);
         }
         #endregion
 

--- a/FluentAutomation/ExpectProvider.cs
+++ b/FluentAutomation/ExpectProvider.cs
@@ -301,7 +301,7 @@ namespace FluentAutomation
 
         private bool IsTextMatch(string elementText, string text)
         {
-            return String.Equals(elementText, text, StringComparison.InvariantCultureIgnoreCase);
+            return string.Equals(elementText, text, StringComparison.InvariantCultureIgnoreCase);
         }
         #endregion
 

--- a/FluentAutomation/PageObject.cs
+++ b/FluentAutomation/PageObject.cs
@@ -80,7 +80,7 @@ namespace FluentAutomation
             {
                 try
                 {
-                    this.At();
+                    newPage.At();
                 }
                 catch (FluentException ex)
                 {


### PR DESCRIPTION
Hello!
I started using FluentAutomation and PageObject stuff and found some issues.
In this pull request:
- fixed: PageObject Switch() calls previous page's At()
- fixed: NullReferenceException in IsTextMatch() function
- fixed: use ex.ScreenshotPath when provider takes screenshot

Cheers, Hal.
