### PR TITLE
Fixed NullReferenceException when DisableStickySession is called

### DIFF
--- a/FluentAutomation/FluentSession.cs
+++ b/FluentAutomation/FluentSession.cs
@@ -80,6 +80,9 @@ namespace FluentAutomation
 
         public static void DisableStickySession()
         {
+            if (FluentSession.Current == null)
+                return;
+            
             FluentSession.Current.SyntaxProviderRegisterOptions.AsMultiInstance();
             FluentSession.Current = null;
             AppDomain.CurrentDomain.DomainUnload -= CurrentDomain_DomainUnload;


### PR DESCRIPTION
I noticed that if `FluentSession.DisableStickySession` is called when `FluentSession.Session` is null, a NullReferenceException occurs. This modification creates a guard against that.
