### PR TITLE
Logic for generating screenshot filename

### DIFF
--- a/FluentAutomation/LocalFileStoreProvider.cs
+++ b/FluentAutomation/LocalFileStoreProvider.cs
@@ -16,8 +16,8 @@ namespace FluentAutomation
                 if (!string.IsNullOrEmpty(settings.ScreenshotPrefix))
                     fileName = settings.ScreenshotPrefix + fileName;
 
-                if (fileName.Substring(0, fileName.Length - 4) != ".png")
-                    fileName += ".png";
+	            if (Path.GetExtension(fileName) != ".png")
+		            fileName += ".png";
 
                 File.WriteAllBytes(Path.Combine(settings.ScreenshotPath, fileName), contents);
                 return true;


### PR DESCRIPTION
I'm confused about this logic, if the `fileName` is `abc.ext` it's asking if `abc` equals `.png` instead of asking what the extension is. That can't be right, right?

Here I've swapped in `Path.GetExtension`, but I'm new to C# and haven't been able to run the test suite of this package so I don't know exactly what the right solution is. Any thoughts?
