### PR TITLE
How to use FindMultiple?

### DIFF
--- a/FluentAutomation.TheInternet.Tests/Actions/FindTests.cs
+++ b/FluentAutomation.TheInternet.Tests/Actions/FindTests.cs
@@ -12,9 +12,29 @@ namespace FluentAutomation.Tests.Actions
 		}
 
 		[Fact]
+		public void FindElement()
+		{
+			var element = I.Find(CheckboxesPage.Checkbox1Selector).Element;
+			Assert.Equal("checkbox", element.Attributes.Get("type"));
+		}
+
+		[Fact]
 		public void TestFindElementThrowsIfElementNotFound()
 		{
 			Assert.Throws<FluentElementNotFoundException>(() => I.Find("doesntexist").Element);
+		}
+
+		[Fact]
+		public void FindMultipleElements()
+		{
+			var elements = I.FindMultiple(CheckboxesPage.AllCheckboxesSelector);
+			Assert.True(elements.Elements.Count > 1);
+
+			// How to access the multiple elements? I would expect this syntax to work:
+			// elements.Elements.ForEach(element =>
+			// {
+			// 	Assert.Equal("checkbox", element.Attributes.Get("type"));
+			// });
 		}
 
 		[Fact]

--- a/FluentAutomation.TheInternet.Tests/Actions/FindTests.cs
+++ b/FluentAutomation.TheInternet.Tests/Actions/FindTests.cs
@@ -1,0 +1,34 @@
+﻿using FluentAutomation.Exceptions;
+using FluentAutomation.Tests.Pages;
+using Xunit;
+
+namespace FluentAutomation.Tests.Actions
+{
+	public class FindTests : BaseTest
+	{
+		public FindTests()
+		{
+			CheckboxesPage.Go();
+		}
+
+		[Fact]
+		public void TestFindElementThrowsIfElementNotFound()
+		{
+			Assert.Throws<FluentElementNotFoundException>(() => I.Find("doesntexist").Element);
+		}
+
+		[Fact]
+		public void TestFindMultipleThrowsIfElementNotFound()
+		{
+			Assert.Throws<FluentElementNotFoundException>(() => I.FindMultiple("doesntexist").Element);
+		}
+
+		[Fact]
+		public void AttemptToFindFakeElement()
+		{
+			var exception = Assert.Throws<FluentElementNotFoundException>(() => I.Find("#fake-control").Element.ToString());
+			// accessing Element executes the Find
+			Assert.True(exception.Message.Contains("Unable to find"));
+		}
+	}
+}

--- a/FluentAutomation.TheInternet.Tests/BaseTest.cs
+++ b/FluentAutomation.TheInternet.Tests/BaseTest.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using FluentAutomation.Tests.Pages;
+using OpenQA.Selenium;
+
+namespace FluentAutomation.Tests
+{
+	/// <summary>
+	///     Base Test that opens the test to the AUT
+	/// </summary>
+	public class BaseTest : FluentTest<IWebDriver>
+	{
+		public CheckboxesPage CheckboxesPage;
+
+		public BaseTest()
+		{
+			FluentSession.EnableStickySession();
+			Config.WaitUntilTimeout(TimeSpan.FromMilliseconds(1000));
+
+			// Create Page Objects
+			CheckboxesPage = new CheckboxesPage(this);
+
+			// Default tests use chrome and load the site
+			SeleniumWebDriver.Bootstrap(SeleniumWebDriver.Browser.Chrome); //, SeleniumWebDriver.Browser.InternetExplorer, SeleniumWebDriver.Browser.Firefox);
+			I.Open(SiteUrl);
+		}
+
+		public string SiteUrl
+		{
+			get { return "http://the-internet.herokuapp.com/"; }
+		}
+	}
+}

--- a/FluentAutomation.TheInternet.Tests/FluentAutomation.TheInternet.Tests.csproj
+++ b/FluentAutomation.TheInternet.Tests/FluentAutomation.TheInternet.Tests.csproj
@@ -1,0 +1,104 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2E384F78-DBDC-4623-AE4A-C37660388A6E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FluentAutomation.Tests</RootNamespace>
+    <AssemblyName>FluentAutomation.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>f8877a84</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="WebDriver, Version=2.41.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.2.41.0\lib\net40\WebDriver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="WebDriver.Support, Version=2.41.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.2.41.0\lib\net40\WebDriver.Support.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit">
+      <HintPath>..\packages\xunit.1.9.0.1566\lib\xunit.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="Actions\FindTests.cs" />
+    <Compile Include="BaseTest.cs" />
+    <Compile Include="Pages\CheckboxesPage.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FluentAutomation.SeleniumWebDriver\FluentAutomation.SeleniumWebDriver.csproj">
+      <Project>{508e97d5-21ef-41dc-8fd1-a0eac0a637a4}</Project>
+      <Name>FluentAutomation.SeleniumWebDriver</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\FluentAutomation.WatiN\FluentAutomation.WatiN.csproj">
+      <Project>{1fa2f73a-72b7-4b4a-94e6-7d5f52425a20}</Project>
+      <Name>FluentAutomation.WatiN</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\FluentAutomation\FluentAutomation.Core.csproj">
+      <Project>{07d8de59-3deb-4722-b093-6fcc0b0f7fff}</Project>
+      <Name>FluentAutomation.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/FluentAutomation.TheInternet.Tests/Pages/CheckboxesPage.cs
+++ b/FluentAutomation.TheInternet.Tests/Pages/CheckboxesPage.cs
@@ -1,0 +1,13 @@
+﻿namespace FluentAutomation.Tests.Pages
+{
+	public class CheckboxesPage : PageObject<CheckboxesPage>
+	{
+		public const string AllCheckboxesSelector = "#checkboxes > input";
+		public const string Checkbox1Selector = "#checkboxes > input:nth-child(1)";
+
+		public CheckboxesPage(FluentTest test) : base(test)
+		{
+			Url = "/checkboxes";
+		}
+	}
+}

--- a/FluentAutomation.TheInternet.Tests/Properties/AssemblyInfo.cs
+++ b/FluentAutomation.TheInternet.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyTitle("FluentAutomation.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("FluentAutomation.Tests")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+
+[assembly: Guid("f98bed17-2b18-4ae8-825d-9542056a3729")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/FluentAutomation.TheInternet.Tests/app.config
+++ b/FluentAutomation.TheInternet.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/FluentAutomation.TheInternet.Tests/packages.config
+++ b/FluentAutomation.TheInternet.Tests/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Selenium.Support" version="2.41.0" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="2.41.0" targetFramework="net40" />
+  <package id="xunit" version="1.9.0.1566" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net40" />
+</packages>

--- a/FluentAutomation.sln
+++ b/FluentAutomation.sln
@@ -25,6 +25,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		pvcfile.csx = pvcfile.csx
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentAutomation.TheInternet.Tests", "FluentAutomation.TheInternet.Tests\FluentAutomation.TheInternet.Tests.csproj", "{2E384F78-DBDC-4623-AE4A-C37660388A6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{D1B0F1F1-CE10-4164-9185-0CCECD007AAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1B0F1F1-CE10-4164-9185-0CCECD007AAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1B0F1F1-CE10-4164-9185-0CCECD007AAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E384F78-DBDC-4623-AE4A-C37660388A6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E384F78-DBDC-4623-AE4A-C37660388A6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E384F78-DBDC-4623-AE4A-C37660388A6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E384F78-DBDC-4623-AE4A-C37660388A6E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hello,

This PR is not necessarily for merging, but rather to highlight a problem I have when working with the framework. I couldn't get the built-in tests working (see #148) so this PR consists of two commits: One that adds a new project to the solution which tests against "[The Internet](http://the-internet.herokuapp.com)", it was the best I could think of for getting some tests going. If I can get the built-in suite going I can trim the fat off this PR.

The second commit is the point of all this, it adds tests for `I.Find` and `I.FindMultiple`. My problem is I can't figure out how to interact with multiple elements, because `FindMultiple` wraps up the underlying elements in too many layers for my current understanding... btw this confusion is also found in existing issues #135 and #117.

So, `Find` is of course simple:

```
var element = I.Find("#some-element").Element;
Assert.Equal("foo", element.Text);
```

But how does one use `FindMultiple` to do the same for multiple objects? I was expecting this to work:

```
var elements = I.FindMultiple(#many-elements).Elements;
elements.ForEach(element =>
{
    Assert.Equal("foo", element.Text);
});
```

But that doesn't work, `Elements` actually returns `List<Tuple<ICommandProvider, Func<IElement>>>` which... I've no clue what to do about, and `Children` returns `List<Func<ElementProxy>>` which almost looks right but how do we get to the elements? How do we actually interact with multiple elements?
