### PR TITLE
Incorrect semicolon placement.

### DIFF
--- a/Docs/docs-v3.0.html
+++ b/Docs/docs-v3.0.html
@@ -1186,7 +1186,7 @@ FluentSession.SetStickySession(this.Session);
         : base(test)
     {
         Url = "<a href='http://bing.com/'>http://bing.com/</a>";
-        At = () =>; I.Expect.Exists(SearchInput);
+        At = () => I.Expect.Exists(SearchInput);
     }
 &nbsp;
     public BingSearchResultsPage Search(string searchText)


### PR DESCRIPTION
Incorrect semicolon placement would cause compilation error if used as is.
