### PR TITLE
Update docs for accessing underlying WebElement

### DIFF
--- a/Docs/v3/actions.find.md
+++ b/Docs/v3/actions.find.md
@@ -15,10 +15,10 @@ Often this function is used to break through the abstraction and get direct acce
 var element = I.Find("#searchBox");
 
 // Get reference to underlying IWebElement (Selenium)
-var webElement = element() as OpenQA.Selenium.IWebElement;
+var webElement = (element.Element as Element)?.WebElement as OpenQA.Selenium.IWebElement;
 
 // Get reference to underlying WatiN.Core.Element (WatiN)
-var webElement = element() as WatiN.Core.Element;
+var webElement = (element.Element as Element)?.WebElement as WatiN.Core.Element;
 
 // Find a collection of elements matching selector
 var listItems = I.FindMultiple("li");


### PR DESCRIPTION
The old documentation had an example that didn't compile for accessing the underlying IWebElement.

var webElement = element() as OpenQA.Selenium.IWebElement;

Have updated to reflect a way that has worked for me to get the underlying element.
