### PR TITLE
Avoids to write the tmpPath if it is already in place.

### DIFF
--- a/FluentAutomation/EmbeddedResources.cs
+++ b/FluentAutomation/EmbeddedResources.cs
@@ -65,8 +65,13 @@ namespace FluentAutomation
             if (filePath != string.Empty && new FileInfo(filePath).Length == resourceStream.Length)
                 return filePath;
 
-            var resourceBytes = new byte[(int)resourceStream.Length];
             var tmpPath = Path.Combine(Path.GetTempPath(), outputFileName);
+            var tmpFileInfo = new FileInfo(tmpPath);
+
+            if (tmpFileInfo.Exists && tmpFileInfo.Length == resourceStream.Length)
+                return tmpPath;
+
+            var resourceBytes = new byte[(int)resourceStream.Length];
             resourceStream.Read(resourceBytes, 0, resourceBytes.Length);
             File.WriteAllBytes(tmpPath, resourceBytes);
 


### PR DESCRIPTION
The tmp file may be readonly in multhreading context, (e.g. running different test on different threads/processes). 
While multiple tests are being executed, the tmpPath file already exists and it is readonly (locked by other threads/processes). The code change does not tries to overwrite the file if it already exists and have the same length
