### PR TITLE
avoid command popups with Phantom,chrome

### DIFF
--- a/FluentAutomation.SeleniumWebDriver/SeleniumWebDriver.cs
+++ b/FluentAutomation.SeleniumWebDriver/SeleniumWebDriver.cs
@@ -245,6 +245,7 @@ namespace FluentAutomation
                     driverPath = EmbeddedResources.UnpackFromAssembly("chromedriver.exe", Assembly.GetAssembly(typeof(SeleniumWebDriver)));
 
                     var chromeService = ChromeDriverService.CreateDefaultService(Path.GetDirectoryName(driverPath));
+                    chromeService.HideCommandPromptWindow = true;
                     chromeService.SuppressInitialDiagnosticInformation = true;
 
                     var chromeOptions = new ChromeOptions();
@@ -253,9 +254,10 @@ namespace FluentAutomation
                     return new Func<IWebDriver>(() => new OpenQA.Selenium.Chrome.ChromeDriver(chromeService, chromeOptions, commandTimeout));
                 case Browser.PhantomJs:
                     driverPath = EmbeddedResources.UnpackFromAssembly("phantomjs.exe", Assembly.GetAssembly(typeof(SeleniumWebDriver)));
-
+                    var phantomService = OpenQA.Selenium.PhantomJS.PhantomJSDriverService.CreateDefaultService(Path.GetDirectoryName(driverPath));
+                    phantomService.HideCommandPromptWindow = true;
                     var phantomOptions = new OpenQA.Selenium.PhantomJS.PhantomJSOptions();
-                    return new Func<IWebDriver>(() => new OpenQA.Selenium.PhantomJS.PhantomJSDriver(Path.GetDirectoryName(driverPath), phantomOptions, commandTimeout));
+                    return new Func<IWebDriver>(() => new OpenQA.Selenium.PhantomJS.PhantomJSDriver(phantomService, phantomOptions, commandTimeout));
             }
 
             throw new NotImplementedException("Selected browser " + browser.ToString() + " is not supported yet.");


### PR DESCRIPTION
When you use PhantomJS with FluentAutomation it currently steals focus and pops up command windows.

I've set the HideCommandPrompt for PhantomJS and chrome

I did the same thing over on SpecBind

https://github.com/dpiessens/specbind/blob/master/src/SpecBind.Selenium/SeleniumBrowserFactory.cs#L70

IE does support this but not through the IEWrapper and I couldn't manage to do it with firefox last time I checked
